### PR TITLE
ユーザーがツイートするフォーマット文字列を設定できるようにした

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,7 +11,6 @@
 // @exclude      https://beta.atcoder.jp/users/*/history/json
 // ==/UserScript==
 
-
 if(!document.URL.match('//beta')) {
 	var betaLink = "beta".link(getBetaURL())
 	$("#main-div > .container").prepend(getWarning(`このサイトは${betaLink}版ではありません。AtCoder_Result_Tweet_Buttonは${betaLink}版でのみ動作します`));
@@ -30,6 +29,8 @@ if (!document.URL.match(`/${userScreenName}`)) {
 	return;
 }
 
+var settings = {};
+settings.dateFormat = "l";
 
 //$.ajaxからデータ取得、これが終わってからメイン処理に移る
 getContestResults()
@@ -38,8 +39,8 @@ getContestResults()
         console.log('AtCoder_Result_Tweet_Buttonは正常に実行されました')
     })
 
-
 function main(contestResults) {
+
     var tweetStr = getTweetStr();
 
     var buttonStr = getButtonStr();
@@ -133,8 +134,7 @@ function main(contestResults) {
             }
         }
     }
-
-
+	
     function getButtonStr() {
         if (contestResults.length === 0) {
             return `ツイート`;
@@ -163,14 +163,10 @@ function main(contestResults) {
             return 75;
         }
     }
-
-
-    function getDate(endtime) {
-        // 2000-01-01 => 2000/1/1
-        var year = endtime.substr(0, 4);
-        var month = endtime.substr(5, 1).replace('0', '') + endtime.substr(6, 1);
-        var day = endtime.substr(8, 1).replace('0', '') + endtime.substr(9, 1);
-        return `${year}/${month}/${day}`;
+	
+	function getDate(endtime) {
+		var time = moment(endtime);
+		return time.format(settings.dateFormat);
     }
 
 

--- a/main.js
+++ b/main.js
@@ -217,7 +217,7 @@ function drawTweetBtn() {
 
 function initSettingsArea() {
     const lsKey = 'AtCoder_Result_Tweet_Button_Settings'
-    settings = getSettingsFromLS();
+    getSettingsFromLS();
     if (!settings) {
         setDefaultSettings();
     }
@@ -234,7 +234,7 @@ function initSettingsArea() {
     $('#tweetbtn-settings textarea,#tweetbtn-settings input').keyup((() => {
         var newSettings = {};
         newSettings = settings;
-		newSettings.tweetFormat = $('#tweetbtn-settings-format').val();
+        newSettings.tweetFormat = $('#tweetbtn-settings-format').val();
         newSettings.dateFormat = $('#tweetbtn-settings-dateformat').val();
         newSettings.RatingHighestString = $('#tweetbtn-settings-highestrating').val();
         newSettings.PerformanceHighestString = $('#tweetbtn-settings-highestperformance').val();

--- a/main.js
+++ b/main.js
@@ -234,7 +234,7 @@ function initSettingsArea() {
     $('#tweetbtn-settings textarea,#tweetbtn-settings input').keyup((() => {
         var newSettings = {};
         newSettings = settings;
-        settings.tweetFormat = $('#tweetbtn-settings-format').val();
+		newSettings.tweetFormat = $('#tweetbtn-settings-format').val();
         newSettings.dateFormat = $('#tweetbtn-settings-dateformat').val();
         newSettings.RatingHighestString = $('#tweetbtn-settings-highestrating').val();
         newSettings.PerformanceHighestString = $('#tweetbtn-settings-highestperformance').val();

--- a/main.js
+++ b/main.js
@@ -13,176 +13,176 @@
 
 
 if(!document.URL.match('//beta')) {
-    alert('このサイトはbeta版ではありません\nAtCoder_Result_Tweet_Buttonはbeta版でのみ動作します');
-} else if(!document.URL.match(`/${userScreenName}`)) {
-    ; // 自分のユーザーページでなければボタンを表示しない
+	alert('このサイトはbeta版ではありません\nAtCoder_Result_Tweet_Buttonはbeta版でのみ動作します');
+	return;
+}
+if (!document.URL.match(`/${userScreenName}`)) {
+	 // 自分のユーザーページでなければボタンを表示しない
+	return;
 }
 
 
-else {
-    //$.ajaxからデータ取得、これが終わってからメイン処理に移る
-    getContestResults()
-        .then(function(data) {
-            main(data);
-            console.log('AtCoder_Result_Tweet_Buttonは正常に実行されました')
-        })
+//$.ajaxからデータ取得、これが終わってからメイン処理に移る
+getContestResults()
+    .then(function(data) {
+        main(data);
+        console.log('AtCoder_Result_Tweet_Buttonは正常に実行されました')
+    })
 
 
-    function main(contestResults) {
-        var tweetStr = getTweetStr();
+function main(contestResults) {
+    var tweetStr = getTweetStr();
 
-        var buttonStr = getButtonStr();
+    var buttonStr = getButtonStr();
 
-        var tweetButton = `<a href="https://twitter.com/intent/tweet?text=${tweetStr}"
-                              class="btn btn-info pull-right"
-                              style="width:${getButtonWidth()}px; height:${getButtonHeight()}px"
-                              rel="nofollow"
-                              onclick="window.open((this.href),'twwindow','width=400, height=250, personalbar=0, toolbar=0, scrollbars=1'); return false;">
-                           ${buttonStr}</a>`;
-                          // ボタンのスタイルはBootstrapで指定
-                          // hrefはdecode -> encodeがよいが、この方法だと'+'がencodeされないので直打ちしている
+    var tweetButton = `<a href="https://twitter.com/intent/tweet?text=${tweetStr}"
+                            class="btn btn-info pull-right"
+                            style="width:${getButtonWidth()}px; height:${getButtonHeight()}px"
+                            rel="nofollow"
+                            onclick="window.open((this.href),'twwindow','width=400, height=250, personalbar=0, toolbar=0, scrollbars=1'); return false;">
+                        ${buttonStr}</a>`;
+                        // ボタンのスタイルはBootstrapで指定
+                        // hrefはdecode -> encodeがよいが、この方法だと'+'がencodeされないので直打ちしている
 
-        var insertElem = getInsertElem();
-        insertElem.insertAdjacentHTML('beforebegin',tweetButton);
+    var insertElem = getInsertElem();
+    insertElem.insertAdjacentHTML('beforebegin',tweetButton);
 
-        if(document.URL.match('/history')) {
-            // 位置調節
-            document.getElementsByClassName('col-sm-6')[1].classList.add('pull-right');
+    if(document.URL.match('/history')) {
+        // 位置調節
+        document.getElementsByClassName('col-sm-6')[1].classList.add('pull-right');
+    }
+
+
+    function getTweetStr() {
+        if (contestResults.length === 0) {
+            return `@chokudai AtCoder初参加します！`;
         }
 
+        else {
+            /*
+            sample1
+            1970/1/1 AtCoder Beginner Contest 999
+            Rank: 1(rated)
+            Perf: 1600(highest!)(inner: 9999)
+            Rating: 9999(+9999, highest!)
+            */
 
-        function getTweetStr() {
-            if (contestResults.length === 0) {
-                return `@chokudai AtCoder初参加します！`;
+            /*
+            sample2
+            1970/1/1 AtCoder Beginner Contest 999
+            Rank: 1(unrated)
+            Perf: 0
+            Rating: 9999(+0)
+            */
+
+
+            var latestContestResult = contestResults[contestResults.length - 1];
+
+            console.log(latestContestResult);
+
+            var contestDate = getDate(latestContestResult.EndTime);
+            var contestName = latestContestResult.ContestName;
+            var rank = latestContestResult.Place;
+            var isRated = latestContestResult.IsRated ? 'rated' : 'unrated';
+            var performance = latestContestResult.Performance;
+            var innerPerformance = latestContestResult.InnerPerformance > performance ? `(inner: ${latestContestResult.InnerPerformance})` : ``;
+            var newRating = latestContestResult.NewRating;
+
+
+            if (contestResults.length === 1){
+                // コンテスト参加回数1回; 前回との比較およびhighest判定なし
+                return `${contestDate} ${contestName}%0aRank: ${rank}(${isRated})%0aPerf: ${performance}${innerPerformance}%0aRating: ${newRating}`;
             }
 
             else {
-                /*
-                sample1
-                1970/1/1 AtCoder Beginner Contest 999
-                Rank: 1(rated)
-                Perf: 1600(highest!)(inner: 9999)
-                Rating: 9999(+9999, highest!)
-                */
+                var secondLatestContestResult = contestResults[contestResults.length - 2];
 
-                /*
-                sample2
-                1970/1/1 AtCoder Beginner Contest 999
-                Rank: 1(unrated)
-                Perf: 0
-                Rating: 9999(+0)
-                */
+                var performanceIsHighest = performanceIsHighest_func(performance);
+                var previousRating = secondLatestContestResult.NewRating;
+                var ratingDiff = newRating - previousRating;
+                var ratingDiffString = (ratingDiff >= 0) ? `%2b${ratingDiff}` : `${ratingDiff}`; //+ or -
+                var ratingIsHighest = ratingIsHighest_func(newRating);
+
+                return `${contestDate} ${contestName}%0aRank: ${rank}(${isRated})%0aPerf: ${performance}${performanceIsHighest}${innerPerformance}%0aRating: ${newRating}(${ratingDiffString}${ratingIsHighest})`;
 
 
-                var latestContestResult = contestResults[contestResults.length - 1];
-
-                console.log(latestContestResult);
-
-                var contestDate = getDate(latestContestResult.EndTime);
-                var contestName = latestContestResult.ContestName;
-                var rank = latestContestResult.Place;
-                var isRated = latestContestResult.IsRated ? 'rated' : 'unrated';
-                var performance = latestContestResult.Performance;
-                var innerPerformance = latestContestResult.InnerPerformance > performance ? `(inner: ${latestContestResult.InnerPerformance})` : ``;
-                var newRating = latestContestResult.NewRating;
-
-
-                if (contestResults.length === 1){
-                    // コンテスト参加回数1回; 前回との比較およびhighest判定なし
-                    return `${contestDate} ${contestName}%0aRank: ${rank}(${isRated})%0aPerf: ${performance}${innerPerformance}%0aRating: ${newRating}`;
+                function performanceIsHighest_func(performance) {
+                    var performanceHistory = [];
+                    for (var i=0; i<contestResults.length; i++) {
+                        performanceHistory.push(contestResults[i].Performance);
+                    }
+                    return (Math.max.apply(null, performanceHistory) === performance) ? '(highest!)' : '';
                 }
 
-                else {
-                    var secondLatestContestResult = contestResults[contestResults.length - 2];
-
-                    var performanceIsHighest = performanceIsHighest_func(performance);
-                    var previousRating = secondLatestContestResult.NewRating;
-                    var ratingDiff = newRating - previousRating;
-                    var ratingDiffString = (ratingDiff >= 0) ? `%2b${ratingDiff}` : `${ratingDiff}`; //+ or -
-                    var ratingIsHighest = ratingIsHighest_func(newRating);
-
-                    return `${contestDate} ${contestName}%0aRank: ${rank}(${isRated})%0aPerf: ${performance}${performanceIsHighest}${innerPerformance}%0aRating: ${newRating}(${ratingDiffString}${ratingIsHighest})`;
-
-
-                    function performanceIsHighest_func(performance) {
-                        var performanceHistory = [];
-                        for (var i=0; i<contestResults.length; i++) {
-                            performanceHistory.push(contestResults[i].Performance);
-                        }
-                        return (Math.max.apply(null, performanceHistory) === performance) ? '(highest!)' : '';
+                function ratingIsHighest_func(rating) {
+                    var ratingHistory = [];
+                    for (var i=0; i<contestResults.length; i++) {
+                        ratingHistory.push(contestResults[i].NewRating);
                     }
-
-                    function ratingIsHighest_func(rating) {
-                        var ratingHistory = [];
-                        for (var i=0; i<contestResults.length; i++) {
-                            ratingHistory.push(contestResults[i].NewRating);
-                        }
-                        return (Math.max.apply(null, ratingHistory) === newRating) ? ', highest!' : '';
-                    }
+                    return (Math.max.apply(null, ratingHistory) === newRating) ? ', highest!' : '';
                 }
-            }
-        }
-
-
-        function getButtonStr() {
-            if (contestResults.length === 0) {
-                return `ツイート`;
-            } else {
-                var latestContestResult = contestResults[contestResults.length - 1];
-                var contestDate = getDate(latestContestResult.EndTime);
-                var contestName = latestContestResult.ContestName;
-                return `${contestDate}<br>${contestName}<br>の結果をツイートする`;
-            }
-        }
-
-        function getButtonWidth() {
-            if (contestResults.length === 0) {
-                return 130;
-            } else {
-                var latestContestResult = contestResults[contestResults.length - 1];
-                var contestName = latestContestResult.ContestName;
-                return contestName.length * 7 + 25;
-            }
-        }
-
-        function getButtonHeight() {
-            if (contestResults.length === 0) {
-                return 35;
-            } else {
-                return 75;
-            }
-        }
-
-
-        function getDate(endtime) {
-            // 2000-01-01 => 2000/1/1
-            var year = endtime.substr(0, 4);
-            var month = endtime.substr(5, 1).replace('0', '') + endtime.substr(6, 1);
-            var day = endtime.substr(8, 1).replace('0', '') + endtime.substr(9, 1);
-            return `${year}/${month}/${day}`;
-        }
-
-
-        function getInsertElem() {
-            if(document.URL.match('/history')) {
-                // コンテスト成績表
-                return document.getElementById('history_wrapper');
-            } else {
-                // プロフィール
-                return document.getElementsByTagName("p")[1];
             }
         }
     }
 
 
-    function getContestResults() {
-        // JQueryのAjax関数; Getでurlからデータを取得し、JSONとして解釈する
-        // userScreenNameはbeta.atcoder.jpのグローバル変数
-        // atcoder.jp(非beta版サイト)はuserScreenNameおよび/history/jsonをサポートしていない
-        return $.ajax({
-            type: 'GET',
-            dataType: 'json',
-            url: `/users/${userScreenName}/history/json`
-        });
+    function getButtonStr() {
+        if (contestResults.length === 0) {
+            return `ツイート`;
+        } else {
+            var latestContestResult = contestResults[contestResults.length - 1];
+            var contestDate = getDate(latestContestResult.EndTime);
+            var contestName = latestContestResult.ContestName;
+            return `${contestDate}<br>${contestName}<br>の結果をツイートする`;
+        }
     }
+
+    function getButtonWidth() {
+        if (contestResults.length === 0) {
+            return 130;
+        } else {
+            var latestContestResult = contestResults[contestResults.length - 1];
+            var contestName = latestContestResult.ContestName;
+            return contestName.length * 7 + 25;
+        }
+    }
+
+    function getButtonHeight() {
+        if (contestResults.length === 0) {
+            return 35;
+        } else {
+            return 75;
+        }
+    }
+
+
+    function getDate(endtime) {
+        // 2000-01-01 => 2000/1/1
+        var year = endtime.substr(0, 4);
+        var month = endtime.substr(5, 1).replace('0', '') + endtime.substr(6, 1);
+        var day = endtime.substr(8, 1).replace('0', '') + endtime.substr(9, 1);
+        return `${year}/${month}/${day}`;
+    }
+
+
+    function getInsertElem() {
+        if(document.URL.match('/history')) {
+            // コンテスト成績表
+            return document.getElementById('history_wrapper');
+        } else {
+            // プロフィール
+            return document.getElementsByTagName("p")[1];
+        }
+    }
+}
+
+function getContestResults() {
+    // JQueryのAjax関数; Getでurlからデータを取得し、JSONとして解釈する
+    // userScreenNameはbeta.atcoder.jpのグローバル変数
+    // atcoder.jp(非beta版サイト)はuserScreenNameおよび/history/jsonをサポートしていない
+    return $.ajax({
+        type: 'GET',
+        dataType: 'json',
+        url: `/users/${userScreenName}/history/json`
+    });
 }

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@
 // @exclude      https://beta.atcoder.jp/users/*/history/json
 // ==/UserScript==
 
+(() => {
 if(!document.URL.match('//beta')) {
 	var betaLink = "beta".link(getBetaURL())
 	$("#main-div > .container").prepend(getWarning(`このサイトは${betaLink}版ではありません。AtCoder_Result_Tweet_Buttonは${betaLink}版でのみ動作します`));
@@ -36,9 +37,10 @@ getContestResults()
         console.log('AtCoder_Result_Tweet_Buttonは正常に実行されました')
     })
 
+
 function main(contestResults) {
 
-    var tweetStr = getTweetStr();
+	var tweetStr = getTweetStr();
 
     var buttonStr = getButtonStr();
 
@@ -58,8 +60,7 @@ function main(contestResults) {
         // 位置調節
         document.getElementsByClassName('col-sm-6')[1].classList.add('pull-right');
     }
-
-
+	
     function getTweetStr() {
         if (contestResults.length === 0) {
             return `@chokudai AtCoder初参加します！`;
@@ -203,3 +204,4 @@ function settings() {
 		localStorage.setItem(lsKey, JSON.stringify(settings));
 	}
 }
+})();

--- a/main.js
+++ b/main.js
@@ -31,6 +31,14 @@ if (!document.URL.match(`/${userScreenName}`)) {
 
 var settings = {};
 settings.dateFormat = 'Y/M/D'
+settings.tweetFormat = 
+`\${ContestDate} \${ContestName}
+Rank: \${Rank}(\${IsRated ? 'rated' : 'unrated'})
+Perf: \${Performance}\${PerformanceHighestString}\${(InnerPerformance !== Performance) ? \`(inner:\${InnerPerformance})\` : ''}
+Rating: \${NewRating}(\${Diff}\${RatingHighestString})`;
+settings.RatingHighestString = ', highest!';
+settings.PerformanceHighestString = '(highest!)';
+
 var contestResults;
 
 appendStyles();
@@ -112,15 +120,16 @@ function drawTweetBtn() {
 
     var buttonStr = getButtonStr();
 
-    var tweetButton = `<a href="https://twitter.com/intent/tweet?text=${tweetStr}"
+	var tweetButton = `<a href="https://twitter.com/intent/tweet?text=${tweetStr}"
                             class="btn btn-info pull-right"
                             rel="nofollow"
                             onclick="window.open((this.href),'twwindow','width=400, height=250, personalbar=0, toolbar=0, scrollbars=1'); return false;"
                             id="${buttonID}">
                         ${buttonStr}</a>`;
                         // ボタンのスタイルはBootstrapで指定
-                        // hrefはdecode -> encodeがよいが、この方法だと'+'がencodeされないので直打ちしている
+                        // hrefはURI用のエンコーダ(encodeURIComponent)を使用し、+や改行もいい感じで処理するようにした
 
+	console.log(tweetButton);
 
     var insertElem = getInsertElem();
     insertElem.insertAdjacentHTML('beforebegin',tweetButton);
@@ -149,19 +158,21 @@ function drawTweetBtn() {
 
         var ContestDate = getDate(contestResult.EndTime);
         var ContestName = contestResult.ContestName;
+		var ContestScreenName = contestResult.ContestScreenName;
         var Rank = contestResult.Place;
 		var IsRated = contestResult.IsRated;
 		var RatingIsHighest = contestResult.RatingIsHighest;
-		var RatingHighestString = RatingIsHighest ? ', highest!' : '';
+		var RatingHighestString = RatingIsHighest ? settings.RatingHighestString : '';
 		var PerformanceIsHighest = contestResult.PerformanceIsHighest;
-		var PerformanceHighestString = PerformanceIsHighest?'(highest!)': '';
+		var PerformanceHighestString = PerformanceIsHighest ? settings.PerformanceHighestString : '';
         var Performance = contestResult.Performance;
         var InnerPerformance = contestResult.InnerPerformance;
         var NewRating = contestResult.NewRating;
 		var OldRating = contestResult.OldRating;
-		var Diff = `${(contestResult.Diff >= 0) ? '%2b' : ''}${contestResult.Diff}`; //+ or -;
+		var Diff = `${(contestResult.Diff >= 0) ? '+' : ''}${contestResult.Diff}`; //+ or -;
 
-		return `${ContestDate} ${ContestName}%0aRank: ${Rank}(${IsRated?'rated':'unrated'})%0aPerf: ${Performance}${PerformanceHighestString}${(InnerPerformance !== Performance)?`(inner:${InnerPerformance})`:''}%0aRating: ${NewRating}(${Diff}${RatingHighestString})`;
+		var tweetStr = eval(`\`${settings.tweetFormat}\``);
+		return encodeURIComponent(tweetStr);
     }
 	
     function getButtonStr() {

--- a/main.js
+++ b/main.js
@@ -12,21 +12,21 @@
 // ==/UserScript==
 (() => {
 if(!document.URL.match('//beta')) {
-	var betaLink = "beta".link(getBetaURL())
-	$("#main-div > .container").prepend(getWarning(`このサイトは${betaLink}版ではありません。AtCoder_Result_Tweet_Buttonは${betaLink}版でのみ動作します`));
-	return;
+    var betaLink = "beta".link(getBetaURL())
+    $("#main-div > .container").prepend(getWarning(`このサイトは${betaLink}版ではありません。AtCoder_Result_Tweet_Buttonは${betaLink}版でのみ動作します`));
+    return;
 
-	function getWarning(content) {
-		return `<div class="alert alert-warning" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="閉じる"><span aria-hidden="true">×</span></button>${content}</div>`;
-	}
+    function getWarning(content) {
+        return `<div class="alert alert-warning" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="閉じる"><span aria-hidden="true">×</span></button>${content}</div>`;
+    }
 
-	function getBetaURL() {
-		return `https://beta.atcoder.jp${document.location.pathname.replace('user', 'users')}`
-	}
+    function getBetaURL() {
+        return `https://beta.atcoder.jp${document.location.pathname.replace('user', 'users')}`
+    }
 }
 if (!document.URL.match(`/${userScreenName}`)) {
-	 // 自分のユーザーページでなければボタンを表示しない
-	return;
+     // 自分のユーザーページでなければボタンを表示しない
+    return;
 }
 
 var settings;
@@ -38,13 +38,13 @@ initSettingsArea();
 //$.ajaxからデータ取得、これが終わってからメイン処理に移る
 getContestResults()
     .then(function(data) {
-		contestResults = shapeData(data);
+        contestResults = shapeData(data);
         drawTweetBtn();
         console.log('AtCoder_Result_Tweet_Buttonは正常に実行されました')
     })
 
 function appendStyles() {
-	const css =
+    const css =
 `a.result-tweet-btn-inline {
     display: inline-block;
     margin: -4px 2px;
@@ -58,62 +58,62 @@ function appendStyles() {
     margin-top: 10px;
 }
 `
-	$('head').append(`<style>${css}</style>`);
+    $('head').append(`<style>${css}</style>`);
 }
 
 function shapeData(data){
-	//データを整形し、ContestScreenName/Diff/IsHighest(Rate|Perf)をいい感じにする
-	var maxPerf = -1;
-	var maxRate = -1;
-	for (var i = 0; i < data.length; i++) {
-		data[i].PerformanceIsHighest = data[i].Performance > maxPerf;
-		data[i].RatingIsHighest = data[i].NewRating > maxRate;
-		data[i].OldRating = i === 0 ? 0 : data[i - 1].NewRating;
-		data[i].Diff = data[i].NewRating - data[i].OldRating;
-		data[i].ContestScreenName = data[i].ContestScreenName.split('.')[0];
+    //データを整形し、ContestScreenName/Diff/IsHighest(Rate|Perf)をいい感じにする
+    var maxPerf = -1;
+    var maxRate = -1;
+    for (var i = 0; i < data.length; i++) {
+        data[i].PerformanceIsHighest = data[i].Performance > maxPerf;
+        data[i].RatingIsHighest = data[i].NewRating > maxRate;
+        data[i].OldRating = i === 0 ? 0 : data[i - 1].NewRating;
+        data[i].Diff = data[i].NewRating - data[i].OldRating;
+        data[i].ContestScreenName = data[i].ContestScreenName.split('.')[0];
 
-		maxPerf = Math.max(maxPerf, data[i].Performance);
-		maxRate = Math.max(maxRate, data[i].NewRating);
-	}
-	return data;
+        maxPerf = Math.max(maxPerf, data[i].Performance);
+        maxRate = Math.max(maxRate, data[i].NewRating);
+    }
+    return data;
 }
 
 function drawTweetBtn() {
 
-	const buttonID = 'result-tweet-btn';
+    const buttonID = 'result-tweet-btn';
 
-	//挿入前に既存要素を削除
-	removeTweetBtn();
+    //挿入前に既存要素を削除
+    removeTweetBtn();
 
-	if(document.URL.match('/history$')) {
-		$('#history > tbody .text-left').each((i,elem) => {
-			var contestName = $('a', elem)[0].textContent;
-			var tweetButton = getInlineTweetButton(contestName);
-			$(elem).append(tweetButton);
-		})
-		// Tooltipの有効化
-		$('[data-toggle="tooltip"]').tooltip();
+    if(document.URL.match('/history$')) {
+        $('#history > tbody .text-left').each((i,elem) => {
+            var contestName = $('a', elem)[0].textContent;
+            var tweetButton = getInlineTweetButton(contestName);
+            $(elem).append(tweetButton);
+        })
+        // Tooltipの有効化
+        $('[data-toggle="tooltip"]').tooltip();
         // 位置調節
-		document.getElementsByClassName('col-sm-6')[1].classList.add('pull-right');
+        document.getElementsByClassName('col-sm-6')[1].classList.add('pull-right');
 
-		function getInlineTweetButton(contestName) {
-			var contestResult = contestResults.find(elem => elem.ContestName === contestName);
-			if (!contestResult) return;
-			var tweetStr = getTweetStr(contestResult);
-			return (
+        function getInlineTweetButton(contestName) {
+            var contestResult = contestResults.find(elem => elem.ContestName === contestName);
+            if (!contestResult) return;
+            var tweetStr = getTweetStr(contestResult);
+            return (
 `<a href="https://twitter.com/intent/tweet?text=${tweetStr}" 
     class="result-tweet-btn-inline" rel="nofollow"
     onclick="window.open((this.href),'twwindow','width=400, height=250, personalbar=0, toolbar=0, scrollbars=1'); return false;"
     data-toggle="tooltip"
     data-original-title="この回の結果をツイート"></a>`);
-		}
+        }
     }
-	
-	var tweetStr = contestResults.length === 0 ? `@chokudai AtCoder初参加します！` :  getTweetStr(contestResults[contestResults.length - 1]);
+    
+    var tweetStr = contestResults.length === 0 ? `@chokudai AtCoder初参加します！` :  getTweetStr(contestResults[contestResults.length - 1]);
 
     var buttonStr = getButtonStr();
 
-	var tweetButton = `<a href="https://twitter.com/intent/tweet?text=${tweetStr}"
+    var tweetButton = `<a href="https://twitter.com/intent/tweet?text=${tweetStr}"
                             class="btn btn-info pull-right"
                             rel="nofollow"
                             onclick="window.open((this.href),'twwindow','width=400, height=250, personalbar=0, toolbar=0, scrollbars=1'); return false;"
@@ -121,13 +121,13 @@ function drawTweetBtn() {
                         ${buttonStr}</a>`;
                         // ボタンのスタイルはBootstrapで指定
                         // hrefはURI用のエンコーダ(encodeURIComponent)を使用し、+や改行もいい感じで処理するようにした
-	
+    
     var insertElem = getInsertElem();
     insertElem.insertAdjacentHTML('beforebegin',tweetButton);
 
-	
-	
-	function getTweetStr(contestResult) {
+    
+    
+    function getTweetStr(contestResult) {
         /*
         sample1
         1970/1/1 AtCoder Beginner Contest 999
@@ -143,29 +143,29 @@ function drawTweetBtn() {
         Perf: 0
         Rating: 9999(+0)
         */
-			
+            
         //console.log(contestResult);
 
 
         var ContestDate = getDate(contestResult.EndTime);
         var ContestName = contestResult.ContestName;
-		var ContestScreenName = contestResult.ContestScreenName;
+        var ContestScreenName = contestResult.ContestScreenName;
         var Rank = contestResult.Place;
-		var IsRated = contestResult.IsRated;
-		var RatingIsHighest = contestResult.RatingIsHighest;
-		var RatingHighestString = RatingIsHighest ? settings.RatingHighestString : '';
-		var PerformanceIsHighest = contestResult.PerformanceIsHighest;
-		var PerformanceHighestString = PerformanceIsHighest ? settings.PerformanceHighestString : '';
+        var IsRated = contestResult.IsRated;
+        var RatingIsHighest = contestResult.RatingIsHighest;
+        var RatingHighestString = RatingIsHighest ? settings.RatingHighestString : '';
+        var PerformanceIsHighest = contestResult.PerformanceIsHighest;
+        var PerformanceHighestString = PerformanceIsHighest ? settings.PerformanceHighestString : '';
         var Performance = contestResult.Performance;
         var InnerPerformance = contestResult.InnerPerformance;
         var NewRating = contestResult.NewRating;
-		var OldRating = contestResult.OldRating;
-		var Diff = `${(contestResult.Diff >= 0) ? '+' : ''}${contestResult.Diff}`; //+ or -;
+        var OldRating = contestResult.OldRating;
+        var Diff = `${(contestResult.Diff >= 0) ? '+' : ''}${contestResult.Diff}`; //+ or -;
 
-		var tweetStr = eval(`\`${settings.tweetFormat}\``);
-		return encodeURIComponent(tweetStr);
+        var tweetStr = eval(`\`${settings.tweetFormat}\``);
+        return encodeURIComponent(tweetStr);
     }
-	
+    
     function getButtonStr() {
         if (contestResults.length === 0) {
             return `ツイート`;
@@ -194,12 +194,12 @@ function drawTweetBtn() {
             return 75;
         }
     }
-	
-	function getDate(endtimestr) {
-		var time = moment(endtimestr);
-		return time.format(settings.dateFormat);
+    
+    function getDate(endtimestr) {
+        var time = moment(endtimestr);
+        return time.format(settings.dateFormat);
     }
-	
+    
     function getInsertElem() {
         if(document.URL.match('/history')) {
             // コンテスト成績表
@@ -208,136 +208,136 @@ function drawTweetBtn() {
             // プロフィール
             return document.getElementsByTagName("p")[1];
         }
-	}
+    }
 
-	function removeTweetBtn() {
-		$(`#${buttonID} , .result-tweet-btn-inline`).remove();
-	}
+    function removeTweetBtn() {
+        $(`#${buttonID} , .result-tweet-btn-inline`).remove();
+    }
 }
 
 function initSettingsArea() {
-	const lsKey = 'AtCoder_Result_Tweet_Button_Settings'
-	settings = getSettingsFromLS();
-	if (!settings) {
-		setDefaultSettings();
-	}
-	//他ウィンドウで設定が更新された時に設定を更新
-	window.addEventListener("storage", function (event) {
-		console.log(event);
-		if (event.key !== lsKey) return;
-		settings = JSON.parse(event.newValue);
-		console.log(settings);
-		drawTweetBtn();
-		drawSettingsArea();
-	})
-	$('#main-container').append(getSettingsDiv());
-	$('#tweetbtn-settings textarea,#tweetbtn-settings input').keyup((() => {
-		var newSettings = {};
-		newSettings = settings;
-		newSettings.dateFormat = $('#tweetbtn-settings-dateformat').val();
-		newSettings.RatingHighestString = $('#tweetbtn-settings-highestrating').val();
-		newSettings.PerformanceHighestString = $('#tweetbtn-settings-highestperformance').val();
-		var result = executeSample(newSettings);
-		$('#tweet-str-settings-formatted').val(result[1]);
-		if(result[0]) {
-			settings = newSettings;
-			setSettingsToLS();
-			drawTweetBtn();
-		}
-	}));
-	drawSettingsArea();
-	function drawSettingsArea() {
-		$('#tweetbtn-settings-dateformat').val(settings.dateFormat);
-		$('#tweetbtn-settings-format').val(settings.tweetFormat);
-		$('#tweetbtn-settings-highestperformance').val(settings.PerformanceHighestString);
-		$('#tweetbtn-settings-highestrating').val(settings.RatingHighestString);
-		$('#tweetbtn-settings-format').val(settings.tweetFormat);
-		var result = executeSample(settings);
-		$('#tweet-str-settings-formatted').val(result[1]);
-	}
-	function executeSample(settings) {
-		contestResult = {}
-		var ContestDate = moment().format(settings.dateFormat);
-		var ContestName = "AtCoder Grand Contest 999";
-		var ContestScreenName = "agc999";
-		var Rank = 100;
-		var IsRated = true;
-		var RatingIsHighest = true;
-		var RatingHighestString = settings.RatingHighestString;
-		var PerformanceIsHighest = true;
-		var PerformanceHighestString = settings.PerformanceHighestString;
-		var Performance = "3000";
-		var InnerPerformance = "3000";
-		var NewRating = "2400";
-		var OldRating = "2300";
-		var Diff = "+100";
+    const lsKey = 'AtCoder_Result_Tweet_Button_Settings'
+    settings = getSettingsFromLS();
+    if (!settings) {
+        setDefaultSettings();
+    }
+    //他ウィンドウで設定が更新された時に設定を更新
+    window.addEventListener("storage", function (event) {
+        console.log(event);
+        if (event.key !== lsKey) return;
+        settings = JSON.parse(event.newValue);
+        console.log(settings);
+        drawTweetBtn();
+        drawSettingsArea();
+    })
+    $('#main-container').append(getSettingsDiv());
+    $('#tweetbtn-settings textarea,#tweetbtn-settings input').keyup((() => {
+        var newSettings = {};
+        newSettings = settings;
+        newSettings.dateFormat = $('#tweetbtn-settings-dateformat').val();
+        newSettings.RatingHighestString = $('#tweetbtn-settings-highestrating').val();
+        newSettings.PerformanceHighestString = $('#tweetbtn-settings-highestperformance').val();
+        var result = executeSample(newSettings);
+        $('#tweet-str-settings-formatted').val(result[1]);
+        if(result[0]) {
+            settings = newSettings;
+            setSettingsToLS();
+            drawTweetBtn();
+        }
+    }));
+    drawSettingsArea();
+    function drawSettingsArea() {
+        $('#tweetbtn-settings-dateformat').val(settings.dateFormat);
+        $('#tweetbtn-settings-format').val(settings.tweetFormat);
+        $('#tweetbtn-settings-highestperformance').val(settings.PerformanceHighestString);
+        $('#tweetbtn-settings-highestrating').val(settings.RatingHighestString);
+        $('#tweetbtn-settings-format').val(settings.tweetFormat);
+        var result = executeSample(settings);
+        $('#tweet-str-settings-formatted').val(result[1]);
+    }
+    function executeSample(settings) {
+        contestResult = {}
+        var ContestDate = moment().format(settings.dateFormat);
+        var ContestName = "AtCoder Grand Contest 999";
+        var ContestScreenName = "agc999";
+        var Rank = 100;
+        var IsRated = true;
+        var RatingIsHighest = true;
+        var RatingHighestString = settings.RatingHighestString;
+        var PerformanceIsHighest = true;
+        var PerformanceHighestString = settings.PerformanceHighestString;
+        var Performance = "3000";
+        var InnerPerformance = "3000";
+        var NewRating = "2400";
+        var OldRating = "2300";
+        var Diff = "+100";
 
-		try {
-			var tweetStr = eval(`\`${settings.tweetFormat}\``);
-			return [true,tweetStr];
-		}
-		catch (e){
-			return [false,e.message];
-		}
-	}
-	function getSettingsFromLS() {
-		settings = JSON.parse(localStorage.getItem(lsKey));
-	}
-	function setSettingsToLS() {
-		localStorage.setItem(lsKey, JSON.stringify(settings));
-	}
-	function setDefaultSettings() {
-		settings = {};
-		settings.dateFormat = 'Y/M/D'
-		settings.tweetFormat =
+        try {
+            var tweetStr = eval(`\`${settings.tweetFormat}\``);
+            return [true,tweetStr];
+        }
+        catch (e){
+            return [false,e.message];
+        }
+    }
+    function getSettingsFromLS() {
+        settings = JSON.parse(localStorage.getItem(lsKey));
+    }
+    function setSettingsToLS() {
+        localStorage.setItem(lsKey, JSON.stringify(settings));
+    }
+    function setDefaultSettings() {
+        settings = {};
+        settings.dateFormat = 'Y/M/D'
+        settings.tweetFormat =
 `\${ContestDate} \${ContestName}
 Rank: \${Rank}(\${IsRated ? 'rated' : 'unrated'})
 Perf: \${Performance}\${PerformanceHighestString}\${(InnerPerformance !== Performance) ? \`(inner:\${InnerPerformance})\` : ''}
 Rating: \${NewRating}(\${Diff}\${RatingHighestString})`;
-		settings.RatingHighestString = ', highest!';
-		settings.PerformanceHighestString = '(highest!)';
-		setSettingsToLS();
-	}
-	function getSettingsDiv() {
-		var dom = 
+        settings.RatingHighestString = ', highest!';
+        settings.PerformanceHighestString = '(highest!)';
+        setSettingsToLS();
+    }
+    function getSettingsDiv() {
+        var dom = 
 `<div class="panel panel-default" id="tweetbtn-settings">
-	<div class="panel-heading"><span class="glyphicon glyphicon-cog"></span>設定</div>
-	<div class="panel-body">
-		<div class="row">
-			<div class="col-sm-4">
-				<label>フォーマット設定</label>
-				<div class="form-group row">
-					<label for="tweetbtn-settings-dateformat" class="col-sm-6 col-form-label" align="right">日付フォーマット</label>
-					<div class="col-sm-6">
-						<input class="form-control" id="tweetbtn-settings-dateformat">
-					</div>
-				</div>
-				<div class="form-group row">
-					<label for="tweetbtn-settings-highestrating" class="col-sm-6 col-form-label" align="right">Hightst(Rating)</label>
-					<div class="col-sm-6">
-						<input class="form-control" id="tweetbtn-settings-highestrating">
-					</div>
-				</div>
-				<div class="form-group row">
-					<label for="tweetbtn-settings-highestperformance" class="col-sm-6 col-form-label" align="right">Hightst(Performance)</label>
-					<div class="col-sm-6">
-						<input class="form-control" id="tweetbtn-settings-highestperformance">
-					</div>
-				</div>
-			</div>
-			<div class="form-group col-sm-4">
-			  <label for="settings-tweet-str">ツイート文字列:</label>
-			  <textarea class="form-control" rows="6" id="tweetbtn-settings-format"></textarea>
-			</div>
-			<div class="form-group col-sm-4">
-			  <label for="settings-tweet-str-formatted">プレビュー:</label>
-			  <textarea class="form-control" rows="6" id="tweet-str-settings-formatted" disabled></textarea>
-			</div>
-		</div>
-	</div>
+    <div class="panel-heading"><span class="glyphicon glyphicon-cog"></span>設定</div>
+    <div class="panel-body">
+        <div class="row">
+            <div class="col-sm-4">
+                <label>フォーマット設定</label>
+                <div class="form-group row">
+                    <label for="tweetbtn-settings-dateformat" class="col-sm-6 col-form-label" align="right">日付フォーマット</label>
+                    <div class="col-sm-6">
+                        <input class="form-control" id="tweetbtn-settings-dateformat">
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label for="tweetbtn-settings-highestrating" class="col-sm-6 col-form-label" align="right">Hightst(Rating)</label>
+                    <div class="col-sm-6">
+                        <input class="form-control" id="tweetbtn-settings-highestrating">
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label for="tweetbtn-settings-highestperformance" class="col-sm-6 col-form-label" align="right">Hightst(Performance)</label>
+                    <div class="col-sm-6">
+                        <input class="form-control" id="tweetbtn-settings-highestperformance">
+                    </div>
+                </div>
+            </div>
+            <div class="form-group col-sm-4">
+              <label for="settings-tweet-str">ツイート文字列:</label>
+              <textarea class="form-control" rows="6" id="tweetbtn-settings-format"></textarea>
+            </div>
+            <div class="form-group col-sm-4">
+              <label for="settings-tweet-str-formatted">プレビュー:</label>
+              <textarea class="form-control" rows="6" id="tweet-str-settings-formatted" disabled></textarea>
+            </div>
+        </div>
+    </div>
 </div>`
-		return dom;
-	}
+        return dom;
+    }
 }
 
 function getContestResults() {

--- a/main.js
+++ b/main.js
@@ -37,12 +37,14 @@ var contestResults;
 getContestResults()
     .then(function(data) {
 		contestResults = data;
-        main();
+        drawTweetBtn();
         console.log('AtCoder_Result_Tweet_Buttonは正常に実行されました')
     })
 
 
-function main() {
+function drawTweetBtn() {
+
+	const buttonID = 'result-tweet-btn';
 
 	var tweetStr = getTweetStr();
 
@@ -52,10 +54,14 @@ function main() {
                             class="btn btn-info pull-right"
                             style="width:${getButtonWidth()}px; height:${getButtonHeight()}px"
                             rel="nofollow"
-                            onclick="window.open((this.href),'twwindow','width=400, height=250, personalbar=0, toolbar=0, scrollbars=1'); return false;">
+                            onclick="window.open((this.href),'twwindow','width=400, height=250, personalbar=0, toolbar=0, scrollbars=1'); return false;"
+                            id="${buttonID}">
                         ${buttonStr}</a>`;
                         // ボタンのスタイルはBootstrapで指定
                         // hrefはdecode -> encodeがよいが、この方法だと'+'がencodeされないので直打ちしている
+
+	//挿入前にすでに要素が存在している場合、要素を削除
+	removeTweetBtn();
 
     var insertElem = getInsertElem();
     insertElem.insertAdjacentHTML('beforebegin',tweetButton);
@@ -179,7 +185,11 @@ function main() {
             // プロフィール
             return document.getElementsByTagName("p")[1];
         }
-    }
+	}
+
+	function removeTweetBtn() {
+		$(`#${buttonID}`).remove();
+	}
 }
 
 function getContestResults() {

--- a/main.js
+++ b/main.js
@@ -238,7 +238,7 @@ function initSettingsArea() {
         newSettings.dateFormat = $('#tweetbtn-settings-dateformat').val();
         newSettings.RatingHighestString = $('#tweetbtn-settings-highestrating').val();
         newSettings.PerformanceHighestString = $('#tweetbtn-settings-highestperformance').val();
-        var result = executeSample(newSettings);
+        var result = getSampleString(newSettings);
         $('#tweet-str-settings-formatted').val(result[1]);
         if(result[0]) {
             settings = newSettings;
@@ -252,10 +252,10 @@ function initSettingsArea() {
         $('#tweetbtn-settings-dateformat').val(settings.dateFormat);
         $('#tweetbtn-settings-highestrating').val(settings.RatingHighestString);
         $('#tweetbtn-settings-highestperformance').val(settings.PerformanceHighestString);
-        var result = executeSample(settings);
+        var result = getSampleString(settings);
         $('#tweet-str-settings-formatted').val(result[1]);
     }
-    function executeSample(settings) {
+    function getSampleString(settings) {
         contestResult = {}
         var ContestDate = moment().format(settings.dateFormat);
         var ContestName = "AtCoder Grand Contest 999";
@@ -337,7 +337,7 @@ Rating: \${NewRating}(\${Diff}\${RatingHighestString})`;
     </div>
 </div>`
         return dom;
-    }
+	}
 }
 
 function getContestResults() {
@@ -350,4 +350,20 @@ function getContestResults() {
         url: `/users/${userScreenName}/history/json`
     });
 }
+
+function ordinalString(i) {
+    var j = i % 10,
+        k = i % 100;
+    if (j == 1 && k != 11) {
+        return i + "st";
+    }
+    if (j == 2 && k != 12) {
+        return i + "nd";
+    }
+    if (j == 3 && k != 13) {
+        return i + "rd";
+    }
+    return i + "th";
+}
+
 })();

--- a/main.js
+++ b/main.js
@@ -33,6 +33,8 @@ if (!document.URL.match(`/${userScreenName}`)) {
 var settings = {};
 var contestResults;
 
+drawSettingsButton();
+
 //$.ajaxからデータ取得、これが終わってからメイン処理に移る
 getContestResults()
     .then(function(data) {
@@ -192,18 +194,7 @@ function drawTweetBtn() {
 	}
 }
 
-function getContestResults() {
-    // JQueryのAjax関数; Getでurlからデータを取得し、JSONとして解釈する
-    // userScreenNameはbeta.atcoder.jpのグローバル変数
-    // atcoder.jp(非beta版サイト)はuserScreenNameおよび/history/jsonをサポートしていない
-    return $.ajax({
-        type: 'GET',
-        dataType: 'json',
-        url: `/users/${userScreenName}/history/json`
-    });
-}
-
-(() => {
+function drawSettingsButton() {
 	const lsKey = 'AtCoder_Result_Tweet_Button_Settings'
 	
 	//他ウィンドウで設定が更新された時に設定を更新
@@ -217,5 +208,16 @@ function getContestResults() {
 	function setSettingsToLS() {
 		localStorage.setItem(lsKey, JSON.stringify(settings));
 	}
-})();
+}
+
+function getContestResults() {
+    // JQueryのAjax関数; Getでurlからデータを取得し、JSONとして解釈する
+    // userScreenNameはbeta.atcoder.jpのグローバル変数
+    // atcoder.jp(非beta版サイト)はuserScreenNameおよび/history/jsonをサポートしていない
+    return $.ajax({
+        type: 'GET',
+        dataType: 'json',
+        url: `/users/${userScreenName}/history/json`
+    });
+}
 })();

--- a/main.js
+++ b/main.js
@@ -29,9 +29,6 @@ if (!document.URL.match(`/${userScreenName}`)) {
 	return;
 }
 
-var settings = {};
-settings.dateFormat = "l";
-
 //$.ajaxからデータ取得、これが終わってからメイン処理に移る
 getContestResults()
     .then(function(data) {
@@ -168,8 +165,7 @@ function main(contestResults) {
 		var time = moment(endtime);
 		return time.format(settings.dateFormat);
     }
-
-
+	
     function getInsertElem() {
         if(document.URL.match('/history')) {
             // コンテスト成績表
@@ -190,4 +186,20 @@ function getContestResults() {
         dataType: 'json',
         url: `/users/${userScreenName}/history/json`
     });
+}
+
+function settings() {
+	const lsKey = 'AtCoder_Result_Tweet_Button_Settings'
+
+	//他ウィンドウで設定が更新された時に設定を更新
+	window.addEventListener("storage", function (event) {
+		if (event.storageArea !== lsKey) return;
+		settings = JSON.stringify(event.newValue);
+	})
+	function getSettingsFromLS() {
+		settings = JSON.parse(localStorage.getItem(lsKey));
+	}
+	function setSettingsToLS() {
+		localStorage.setItem(lsKey, JSON.stringify(settings));
+	}
 }

--- a/main.js
+++ b/main.js
@@ -234,6 +234,7 @@ function initSettingsArea() {
     $('#tweetbtn-settings textarea,#tweetbtn-settings input').keyup((() => {
         var newSettings = {};
         newSettings = settings;
+        settings.tweetFormat = $('#tweetbtn-settings-format').val();
         newSettings.dateFormat = $('#tweetbtn-settings-dateformat').val();
         newSettings.RatingHighestString = $('#tweetbtn-settings-highestrating').val();
         newSettings.PerformanceHighestString = $('#tweetbtn-settings-highestperformance').val();
@@ -247,11 +248,10 @@ function initSettingsArea() {
     }));
     drawSettingsArea();
     function drawSettingsArea() {
+        $('#tweetbtn-settings-format').val(settings.tweetFormat);
         $('#tweetbtn-settings-dateformat').val(settings.dateFormat);
-        $('#tweetbtn-settings-format').val(settings.tweetFormat);
-        $('#tweetbtn-settings-highestperformance').val(settings.PerformanceHighestString);
         $('#tweetbtn-settings-highestrating').val(settings.RatingHighestString);
-        $('#tweetbtn-settings-format').val(settings.tweetFormat);
+        $('#tweetbtn-settings-highestperformance').val(settings.PerformanceHighestString);
         var result = executeSample(settings);
         $('#tweet-str-settings-formatted').val(result[1]);
     }

--- a/main.js
+++ b/main.js
@@ -13,8 +13,17 @@
 
 
 if(!document.URL.match('//beta')) {
-	alert('このサイトはbeta版ではありません\nAtCoder_Result_Tweet_Buttonはbeta版でのみ動作します');
+	var betaLink = "beta".link(getBetaURL())
+	$("#main-div > .container").prepend(getWarning(`このサイトは${betaLink}版ではありません。AtCoder_Result_Tweet_Buttonは${betaLink}版でのみ動作します`));
 	return;
+
+	function getWarning(content) {
+		return `<div class="alert alert-warning" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="閉じる"><span aria-hidden="true">×</span></button>${content}</div>`;
+	}
+
+	function getBetaURL() {
+		return `https://beta.atcoder.jp${document.location.pathname.replace('user', 'users')}`
+	}
 }
 if (!document.URL.match(`/${userScreenName}`)) {
 	 // 自分のユーザーページでなければボタンを表示しない

--- a/main.js
+++ b/main.js
@@ -10,7 +10,6 @@
 // @match        https://atcoder.jp/user/*
 // @exclude      https://beta.atcoder.jp/users/*/history/json
 // ==/UserScript==
-
 (() => {
 if(!document.URL.match('//beta')) {
 	var betaLink = "beta".link(getBetaURL())
@@ -30,15 +29,20 @@ if (!document.URL.match(`/${userScreenName}`)) {
 	return;
 }
 
+
+var settings = {};
+var contestResults;
+
 //$.ajaxからデータ取得、これが終わってからメイン処理に移る
 getContestResults()
     .then(function(data) {
-        main(data);
+		contestResults = data;
+        main();
         console.log('AtCoder_Result_Tweet_Buttonは正常に実行されました')
     })
 
 
-function main(contestResults) {
+function main() {
 
 	var tweetStr = getTweetStr();
 
@@ -189,9 +193,9 @@ function getContestResults() {
     });
 }
 
-function settings() {
+(() => {
 	const lsKey = 'AtCoder_Result_Tweet_Button_Settings'
-
+	
 	//他ウィンドウで設定が更新された時に設定を更新
 	window.addEventListener("storage", function (event) {
 		if (event.storageArea !== lsKey) return;
@@ -203,5 +207,5 @@ function settings() {
 	function setSettingsToLS() {
 		localStorage.setItem(lsKey, JSON.stringify(settings));
 	}
-}
+})();
 })();


### PR DESCRIPTION
ユーザーがツイートするフォーマット文字列を設定できるようにしました。それに加え、いくつかの大きな変更を加えてしまっています。(ごめんなさい)
もちろんマージした後に元に戻してしてしまって問題ないです

### メイン機能
ツイートするフォーマット文字列を設定できるようにした
設定画面をつけた(タブ間で変更するとすぐさま同期を取るようにした。2つタブを開いていじると楽しい)
![image](https://user-images.githubusercontent.com/32513370/43990259-6ec492e6-9d94-11e8-8387-4309f27fd45e.png)
コンテスト履歴画面において、全コンテストの横にツイートボタンを追加した
![image](https://user-images.githubusercontent.com/32513370/43990311-753938ce-9d95-11e8-8239-7014f53eb387.png)
ベータ版を使っていないときのアラートを、bootstrapの警告要素の追加に変更した
![image](https://user-images.githubusercontent.com/32513370/43990316-87763118-9d95-11e8-8abb-9e058f42a85b.png)
### コードの大きな変更
main関数外でいろいろやってしまったため、名称をdrawTweetBtnに変更した。それに伴い、contestResultsを外に出した。
contestResultそれぞれにDiff/IsHighest/OldRating/ContestScreenNameを追加した。この作業はshapeData関数にて行っている。
CSSを追加する関数(appendStyles)を追加した。
settingオブジェクト、設定ボタン追加関数を追加した。

### コードの小さなリファクタリング的変更
ガード節を追加した(if(a) - else if(b) - elseでネストが深くなっていたので、if(!a) return; if(!b) return;とした) それに伴い、全体を匿名関数で囲った(これはUserScriptマネージャの仕様によって、グローバル変数を汚染してしまう問題も防げる)
Height,Widthを計算していたが、Autoと変わらないと思ったので消した。
正規表現を変更した箇所がある(終端文字を付け足すなど)
日付をsplitなどを使ってパースしていたのを、moment.js(beta版AtCoderに元からImportされているライブラリ)を使ってパースするようにした。日付フォーマットもこれによって実現されている。

折り畳み機能、追加機能の細かいDIsable設定は諦めましたが、必要ならば追加します。(正直下に出っ張っている設定画面が鬱陶しいのは自覚しているので、早々に最小化/折りたたみ機能は追加したいです)